### PR TITLE
Dist view page

### DIFF
--- a/lib/CPAN/Testers/Web.pm
+++ b/lib/CPAN/Testers/Web.pm
@@ -47,11 +47,44 @@ sub startup ( $app ) {
         catdir( dist_dir( 'CPAN-Testers-Web' ), 'public' );
     unshift @{ $app->commands->namespaces }, 'CPAN::Testers::Web::Command';
 
+
     $app->moniker( 'web' );
     # This application has no configuration yet
     $app->plugin( Config => {
         default => {
             api_host => 'api.cpantesters.org',
+            dist_modules => [qw/
+                Mojolicious
+                Moose
+                Moo
+                DBIx-Class
+                App-cpanminus
+                DBI
+                Plack
+                DateTime
+                Devel-NYTProf
+                Test-Simple
+                Path-Tiny
+                Dist-Zilla
+                Scalar-List-Utils
+                App-perlbrew
+                Try-Tiny
+                libwww-perl
+                AnyEvent
+                Catalyst-Runtime
+                Data-Printer
+                Dancer
+                Template-Toolkit
+                Type-Tiny
+                Perl-Tidy
+                Dancer2
+                Perl-Critic
+                ack
+                Carton
+                Getopt-Long
+                List-MoreUtils
+                Task-Kensho
+            /]
         },
     } );
 
@@ -222,12 +255,9 @@ sub startup ( $app ) {
       ->name( 'release.dist' )
       ->to( 'reports#dist_versions' );
 
-    $r->get( '/dist' )
-      ->name( 'dist-search' )
-      ->to( cb => sub {
-        my ( $c ) = @_;
-        $c->render( 'dist-search' );
-    } );
+    $r->get( '/dist' )->name( 'dist-search' )->to( 'dist#search' );
+    $r->post( '/dist' )->name( 'dist-recent' )->to( 'dist#recent' );
+    $r->post( '/dist/valid' )->name( 'dist-valid' )->to( 'dist#valid' );
 
     $r->get( '/author/:author', [ format => [qw( html rss json)] ] )
       ->name( 'reports.author' )

--- a/lib/CPAN/Testers/Web.pm
+++ b/lib/CPAN/Testers/Web.pm
@@ -247,14 +247,16 @@ sub startup ( $app ) {
         $c->render( 'user/dist/settings' );
     } );
 
-    $r->get( '/dist/:dist/#version', [ format => [qw( html rss )] ], { format => 'html', version => 'latest' } )
-      ->name( 'reports.dist' )
-      ->to( 'reports#dist_reports' );
-
     $r->get( '/release/:dist', [ format => [qw( json )] ], { format => 'json' } )
       ->name( 'release.dist' )
       ->to( 'reports#dist_versions' );
 
+    $r->get( '/dist/:dist' )->name( 'dist-view' )->to( 'dist#view', [ format => [qw(html)] ], { format => 'html', version => 'latest' } );
+    $r->get( '/dist/:dist/releases' )->name( 'dist-releases' )->to( 'dist#releases' );
+
+    $r->get( '/dist/:dist/releases/#version' )->name( 'dist-reports' )->to( 'dist#reports' );
+
+    $r->get( '/dist/:dist/#version' )->name( 'dist-view' )->to( 'dist#view', [ format => [qw(html)] ], { format => 'html', version => 'latest' } );
     $r->get( '/dist' )->name( 'dist-search' )->to( 'dist#search' );
     $r->post( '/dist' )->name( 'dist-recent' )->to( 'dist#recent' );
     $r->post( '/dist/valid' )->name( 'dist-valid' )->to( 'dist#valid' );

--- a/lib/CPAN/Testers/Web/Controller/Dist.pm
+++ b/lib/CPAN/Testers/Web/Controller/Dist.pm
@@ -1,0 +1,66 @@
+package CPAN::Testers::Web::Controller::Dist;
+our $VERSION = '0.001';
+# ABSTRACT: Endpoints for viewing and managing distributions
+
+=head1 DESCRIPTION
+
+=head1 SEE ALSO
+
+=cut
+
+use Mojo::Base 'Mojolicious::Controller';
+use CPAN::Testers::Web::Base;
+use CPAN::Testers::Web::Controller::Legacy;
+
+=method search
+
+Landing page for /dist
+
+Lists modules configured in the config
+
+=cut
+
+sub search ( $c ) {
+
+	$c->render('dist-search', {
+			
+	});
+}
+
+=method recent_uploads
+
+List the recent uploads to CPAN and the reports received so far.
+
+=cut
+
+sub recent_uploads( $c ) {
+    # XXX: Disabling for now as too slow
+    # my $recent_uploads = $c->schema->perl5->resultset('Upload')->recent(20);
+    # my $rs = $c->schema->perl5->resultset('Release')->search({
+    #         -or => [
+    #             map +{ 'me.dist' => $_->dist, 'me.version' => $_->version }, $recent_uploads->all
+    #         ]
+    #     },
+    #     {
+    #         join => 'upload',
+    #         order_by => { -desc => 'upload.released' },
+    #         group_by => [qw( me.dist me.version )],
+    #         select => [qw( dist version uploadid upload.author upload.released), \('COUNT(*)', 'SUM(pass)', 'SUM(fail)', 'SUM(na)', 'SUM(unknown)') ],
+    #         as => [qw( dist version uploadid author released total pass fail na unknown )],
+    #     }
+    # );
+
+    $c->render( 'reports/recent_uploads',
+        items => []
+        # items => [
+        #     map +{
+        #         $_->get_inflated_columns,
+        #         released => $_->upload->released->datetime( ' ' ),
+        #     },
+        #     $rs->all
+        # ],
+    );
+}
+
+
+1;

--- a/lib/CPAN/Testers/Web/Controller/Dist.pm
+++ b/lib/CPAN/Testers/Web/Controller/Dist.pm
@@ -73,11 +73,19 @@ validate that a dist exists
 
 sub valid ( $c ) {
     my $rs = $c->schema->perl5->resultset('Release')->search({
-        dist => $c->req->json->{dist}
+        dist =>  { like => $c->req->json->{dist} . '%' }
+    }, {
+        distinct => 1,
+        select => ['dist'],
+        as => ['dist'],
+        rows => 50
     });
 
     $c->render( json => {
-        ok => $rs->count()
+        dists => [
+            map { $_->dist }
+            $rs->all
+        ]
     } );
 }
 

--- a/lib/CPAN/Testers/Web/Controller/Dist.pm
+++ b/lib/CPAN/Testers/Web/Controller/Dist.pm
@@ -21,46 +21,64 @@ Lists modules configured in the config
 =cut
 
 sub search ( $c ) {
-
-	$c->render('dist-search', {
-			
-	});
+	$c->render('dist/search',
+		dists => $c->config->{dist_modules}
+	);
 }
 
-=method recent_uploads
+=method recent
 
-List the recent uploads to CPAN and the reports received so far.
+Expects a list of dists and will return the most recent for each.
 
 =cut
 
-sub recent_uploads( $c ) {
-    # XXX: Disabling for now as too slow
-    # my $recent_uploads = $c->schema->perl5->resultset('Upload')->recent(20);
-    # my $rs = $c->schema->perl5->resultset('Release')->search({
-    #         -or => [
-    #             map +{ 'me.dist' => $_->dist, 'me.version' => $_->version }, $recent_uploads->all
-    #         ]
-    #     },
-    #     {
-    #         join => 'upload',
-    #         order_by => { -desc => 'upload.released' },
-    #         group_by => [qw( me.dist me.version )],
-    #         select => [qw( dist version uploadid upload.author upload.released), \('COUNT(*)', 'SUM(pass)', 'SUM(fail)', 'SUM(na)', 'SUM(unknown)') ],
-    #         as => [qw( dist version uploadid author released total pass fail na unknown )],
-    #     }
-    # );
+sub recent ( $c ) {
+    my $join = $c->schema->perl5->resultset('Release')->search({
+        dist => { -in => $c->req->json->{dists} }
+    }, {
+        group_by => [qw( me.dist )],
+        select => [qw/dist/, \('MAX(version)')],
+        as => [qw/dist version/]
+    });
 
-    $c->render( 'reports/recent_uploads',
-        items => []
-        # items => [
-        #     map +{
-        #         $_->get_inflated_columns,
-        #         released => $_->upload->released->datetime( ' ' ),
-        #     },
-        #     $rs->all
-        # ],
-    );
+    if (!$join->count) {
+        return $c->render( json => { dists => [] } );
+    }
+
+    my $rs = $c->schema->perl5->resultset('Release')->search({
+        -or => [
+                map +{ 'me.dist' => $_->dist, 'me.version' => $_->version }, $join->all()
+        ],
+    }, {
+        join => 'upload'
+    });
+
+    $c->render( json => {
+        dists => [
+            map +{
+                $_->get_inflated_columns,
+                released => $_->upload->released->datetime( ' ' ),
+            },
+            $rs->all
+        ]
+
+    } );
 }
 
+=method valid
+
+validate that a dist exists
+
+=cut
+
+sub valid ( $c ) {
+    my $rs = $c->schema->perl5->resultset('Release')->search({
+        dist => $c->req->json->{dist}
+    });
+
+    $c->render( json => {
+        ok => $rs->count()
+    } );
+}
 
 1;

--- a/share/public/css/cpantesters.css
+++ b/share/public/css/cpantesters.css
@@ -21,6 +21,57 @@ body {
     min-width: 150px;
 }
 
+.loading-content {
+    position: relative;
+    width: 100%;
+    height: 400px;
+    margin-top: 1em;
+    overflow: hidden;
+    border: 1px solid rgb(220, 224, 227);
+    background-color: rgb(240, 244, 247);
+}
+.loading-content:after {
+    content: "";
+    display: block;
+    position: absolute;
+    height: 100%;
+    width: 20%;
+    top: 0;
+    animation: load 1s 1s infinite;
+    background-image: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 0.5) 50%,
+        rgba(255, 255, 255, 0) 100%
+    );
+}
+.loading-content.small-graph, .small-graph {
+    height: 300px;
+    width: 25%;
+}
+.flex {
+    display: flex;
+    width: 100%;
+}
+.flex-justify {
+    justify-content: space-between;
+    align-content: center;
+    align-items: center;
+}
+.bg-unknown {
+    background: #f6ddc3;
+}
+
+
+@keyframes load {
+    from {
+        left: -100px;
+    }
+    to {
+      left: 100%;
+    }
+}
+
 @media only screen and (max-width: 600px) {
     #popular tr th:first-child {
         min-width: auto;

--- a/share/public/css/cpantesters.css
+++ b/share/public/css/cpantesters.css
@@ -16,3 +16,13 @@ body {
     margin-bottom: 1em;
 }
 
+
+#popular tr th:first-child {
+    min-width: 150px;
+}
+
+@media only screen and (max-width: 600px) {
+    #popular tr th:first-child {
+        min-width: auto;
+    }
+}

--- a/share/public/css/cpantesters.css
+++ b/share/public/css/cpantesters.css
@@ -49,6 +49,9 @@ body {
     height: 300px;
     width: 25%;
 }
+.loading-content.loading-content-short-height {
+    height: 110px;
+}
 .flex {
     display: flex;
     width: 100%;

--- a/share/templates/dist/search.html.ep
+++ b/share/templates/dist/search.html.ep
@@ -1,0 +1,97 @@
+
+% title 'Search Distributions';
+
+<div class="container">
+    <div class="row">
+        <div class="col-md-12">
+
+            <h1>Search Distributions</h1>
+
+            <form class="form-inline">
+                <div class="form-group">
+                    <label for="search">Search:</label>
+                    <input id="search" class="form-control"
+                        placeholder="Search Distributions"
+                    >
+                </div>
+                <button class="btn btn-primary">Search</button>
+            </form>
+
+            <h2>Results</h2>
+
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Distribution</th>
+                        <th>Last Version</th>
+                        <th>Released</th>
+                        <th class="text-center">Reports</th>
+                        <th class="text-center">Pass</th>
+                        <th class="text-center">Fail</th>
+                    </tr>
+                </thead>
+                <tbody>
+
+                    <tr>
+                        <td>
+                            <a href="/dist/Statocles">Statocles</a>
+                        </td>
+                        <td>0.066</td>
+                        <td>
+                            <time>2015-01-11 00:12:34</time>
+                        </td>
+                        <td class="text-center">
+                            12
+                        </td>
+                        <td class="bg-success text-center">
+                            11
+                        </td>
+                        <td class="bg-warning text-center">
+                            1
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td>
+                            <a href="/dist/Beam-Wire">Beam-Wire</a>
+                        </td>
+                        <td>1.011</td>
+                        <td>
+                            <time>2015-01-10 01:24:12</time>
+                        </td>
+                        <td class="text-center">
+                            50
+                        </td>
+                        <td class="bg-success text-center">
+                            50
+                        </td>
+                        <td class="bg-success text-center">
+                            0
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td>
+                            <a href="/dist/Import-Base">Import-Base</a>
+                        </td>
+                        <td>1.001</td>
+                        <td>
+                            <time>2015-01-07 01:24:12</time>
+                        </td>
+                        <td class="text-center">
+                            74
+                        </td>
+                        <td class="bg-success text-center">
+                            70
+                        </td>
+                        <td class="bg-warning text-center">
+                            4
+                        </td>
+                    </tr>
+
+                </tbody>
+            </table>
+
+        </div>
+    </div>
+</div>

--- a/share/templates/dist/search.html.ep
+++ b/share/templates/dist/search.html.ep
@@ -7,7 +7,7 @@
 
             <h1>Search Distributions</h1>
 
-            <form class="form-inline">
+            <form id="search-form" class="form-inline">
                 <div class="form-group">
                     <label for="search">Search:</label>
                     <input id="search" class="form-control"
@@ -19,7 +19,7 @@
 
             <h2>Results</h2>
 
-            <table class="table table-striped">
+            <table id="popular" class="table table-striped">
                 <thead>
                     <tr>
                         <th>Distribution</th>
@@ -28,70 +28,124 @@
                         <th class="text-center">Reports</th>
                         <th class="text-center">Pass</th>
                         <th class="text-center">Fail</th>
+                        <th class="text-center">Unkn</th>
+                        <th class="text-center">NA</th>
                     </tr>
                 </thead>
                 <tbody>
+                    <template>
+                        <tr>
+                            <td>
+                                <a data-id="dist" href="/dist/Statocles">Statocles</a>
+                            </td>
+                            <td data-id="version">0.066</td>
+                            <td>
+                                <time data-id="released">2015-01-11 00:12:34</time>
+                            </td>
+                            <td data-id="total" class="text-center">
+                                12
+                            </td>
+                            <td data-id="pass" class="bg-success text-center">
+                                11
+                            </td>
+                            <td data-id="fail" class="text-center">
+                                1
+                            </td>
+                            <td data-id="unknown" class="text-center">
+                                1
+                            </td>
+                            <td data-id="na" class="text-center">
+                                1
+                            </td>
+                        </tr>
+                    </template>
 
-                    <tr>
-                        <td>
-                            <a href="/dist/Statocles">Statocles</a>
-                        </td>
-                        <td>0.066</td>
-                        <td>
-                            <time>2015-01-11 00:12:34</time>
-                        </td>
-                        <td class="text-center">
-                            12
-                        </td>
-                        <td class="bg-success text-center">
-                            11
-                        </td>
-                        <td class="bg-warning text-center">
-                            1
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <td>
-                            <a href="/dist/Beam-Wire">Beam-Wire</a>
-                        </td>
-                        <td>1.011</td>
-                        <td>
-                            <time>2015-01-10 01:24:12</time>
-                        </td>
-                        <td class="text-center">
-                            50
-                        </td>
-                        <td class="bg-success text-center">
-                            50
-                        </td>
-                        <td class="bg-success text-center">
-                            0
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <td>
-                            <a href="/dist/Import-Base">Import-Base</a>
-                        </td>
-                        <td>1.001</td>
-                        <td>
-                            <time>2015-01-07 01:24:12</time>
-                        </td>
-                        <td class="text-center">
-                            74
-                        </td>
-                        <td class="bg-success text-center">
-                            70
-                        </td>
-                        <td class="bg-warning text-center">
-                            4
-                        </td>
-                    </tr>
 
                 </tbody>
             </table>
+            <script>
+                (function () {
 
+                    let Dist = function (dists) {
+                        this.search_form = document.querySelector('#search-form');
+                        this.tbody = document.querySelector('#popular tbody');
+                        this.template = this.tbody.querySelector('template');
+                        this.init(dists);
+                    };
+
+                    Dist.prototype = {
+                        init: function (dists) {
+                            this.setupEvents();
+                            this.poll(dists, 0);
+                        },
+                        setupEvents: function () {
+                            let self = this;
+                            let input = self.search_form.querySelector('input#search');
+                            self.search_form.addEventListener('submit', function (evt) {
+                                evt.preventDefault();
+                                self.request('/dist/valid', { dist: input.value }, function (res) {
+                                    if (res.ok) {
+                                        window.location.pathname = '/dist/' + input.value;
+                                    } else {
+                                        alert('Distribution with the name ' + input.value + ' not found');
+                                    }
+                                });
+                            });
+                        },
+                        poll: function (dists, inc) {
+                            let self = this;
+                            if (inc < 10) inc++;
+                            let pdists = dists.splice(0, inc);
+                            console.log(dists);
+                            self.request('/dist', { dists: pdists }, function (res) {
+                                res.dists.forEach(function (dist) {
+                                    self.render_dist(dist);
+                                });
+                                if (dists.length > 0) self.poll(dists, inc);
+                            });
+                        },
+                        request: function (url, params, cb) {
+                            fetch(url, {
+                                method: "POST",
+                                body: JSON.stringify(params),
+                            }).then(function (res) {
+                                return res.json();
+                            }).then(function (res) {
+                                cb(res);
+                            }).catch(function (res) {
+                                 console.log(res);
+                            });
+                        },
+                        render_dist: function (dist) {
+                            let tr = this.template.content.cloneNode(true);
+                            let name = tr.querySelector('[data-id="dist"]');
+                            name.innerText = dist.dist;
+                            name.href = '/dist/' + dist.dist;
+                            dist.total = dist.pass + dist.fail + dist.unknown + dist.na;
+                            ['version', 'released', 'total', 'pass'].forEach(function (n) {
+                                tr.querySelector('[data-id="' + n + '"]').innerText = dist[n];
+                            });
+                            let fail = tr.querySelector('[data-id="fail"]');
+                            fail.innerText = dist.fail;
+                            fail.classList.add(dist.fail ? 'bg-danger' : 'bg-success');
+                            ['unknown', 'na'].forEach(function (n) {
+                                let x = tr.querySelector('[data-id="' + n + '"]');
+                                x.innerText = dist[n];
+                                x.classList.add(dist[n] ? 'bg-warning' : 'bg-success');
+                            });
+                            this.tbody.appendChild(tr);
+                        }
+                    };
+
+                    let dists = [
+                        % for my $dist (@$dists) {
+                            "<%= $dist %>",
+                        % }
+                    ];
+
+                    new Dist(dists);
+                })();
+            </script>
         </div>
     </div>
 </div>

--- a/share/templates/dist/search.html.ep
+++ b/share/templates/dist/search.html.ep
@@ -17,7 +17,7 @@
                 <button class="btn btn-primary">Search</button>
             </form>
 
-            <h2>Results</h2>
+            <h2 id="search-title">Popular Distributions</h2>
 
             <table id="popular" class="table table-striped">
                 <thead>
@@ -67,6 +67,7 @@
                 (function () {
 
                     let Dist = function (dists) {
+                        this.title = document.querySelector('#search-title');
                         this.search_form = document.querySelector('#search-form');
                         this.tbody = document.querySelector('#popular tbody');
                         this.template = this.tbody.querySelector('template');
@@ -74,33 +75,81 @@
                     };
 
                     Dist.prototype = {
+                        active_type: 'popular',
                         init: function (dists) {
                             this.setupEvents();
-                            this.poll(dists, 0);
+                            this.poll(dists, 'popular', 0);
                         },
                         setupEvents: function () {
                             let self = this;
                             let input = self.search_form.querySelector('input#search');
+                            let last_search = "";
                             self.search_form.addEventListener('submit', function (evt) {
                                 evt.preventDefault();
+
+                                if (!input.value) {
+                                    return self.switchPopularMode();
+                                }
+
+                                if (last_search == input.value) return;
+
+                                last_search = input.value;
+
                                 self.request('/dist/valid', { dist: input.value }, function (res) {
-                                    if (res.ok) {
-                                        window.location.pathname = '/dist/' + input.value;
-                                    } else {
+                                    if (!res.dists || !res.dists.length) {
                                         alert('Distribution with the name ' + input.value + ' not found');
+                                        return;
                                     }
+
+                                    self.switchSearchMode(input.value);
+
+                                    self.tbody.querySelectorAll('.search-dist').forEach(function (n) {
+                                        n.remove();
+                                    });
+
+                                    self.poll(res.dists, input.value, 0);
                                 });
                             });
                         },
-                        poll: function (dists, inc) {
+                        switchSearchMode: function (type) {
+                            let self = this;
+
+                            self.active_type = type;
+
+                            self.title.innerText = 'Search results';
+
+                            self.tbody.querySelectorAll('.popular-dist').forEach(function (n) {
+                                n.classList.add('hide');;
+                            });
+
+                        },
+                        switchPopularMode: function () {
+                            let self = this;
+
+                            self.active_type = 'popular';
+
+                            self.title.innerText = 'Popular Distributions';
+
+                            self.tbody.querySelectorAll('.popular-dist').forEach(function (n) {
+                                n.classList.remove('hide');;
+                            });
+
+                            self.tbody.querySelectorAll('.search-dist').forEach(function (n) {
+                                n.remove();
+                            });
+                        },
+                        poll: function (dists, type, inc) {
                             let self = this;
                             if (inc < 10) inc++;
                             let pdists = dists.splice(0, inc);
                             self.request('/dist', { dists: pdists }, function (res) {
                                 res.dists.forEach(function (dist) {
-                                    self.render_dist(dist);
+                                    self.render_dist(dist, type);
                                 });
-                                if (dists.length > 0) self.poll(dists, inc);
+                                if (
+                                    (type == 'popular' || type == self.active_type)
+                                        && dists.length > 0
+                                ) self.poll(dists, type, inc);
                             });
                         },
                         request: function (url, params, cb) {
@@ -115,7 +164,7 @@
                                  console.log(res);
                             });
                         },
-                        render_dist: function (dist) {
+                        render_dist: function (dist, type) {
                             let tr = this.template.content.cloneNode(true);
                             let name = tr.querySelector('[data-id="dist"]');
                             name.innerText = dist.dist;
@@ -132,6 +181,10 @@
                                 x.innerText = dist[n];
                                 x.classList.add(dist[n] ? 'bg-warning' : 'bg-success');
                             });
+                            tr.firstElementChild.classList.add(type == "popular" ? "popular-dist" : "search-dist");
+                            if (type != this.active_type) {
+                                tr.firstElementChild.classList.add("hide");
+                            }
                             this.tbody.appendChild(tr);
                         }
                     };

--- a/share/templates/dist/search.html.ep
+++ b/share/templates/dist/search.html.ep
@@ -110,6 +110,10 @@
                                     self.poll(res.dists, input.value, 0);
                                 });
                             });
+
+                            input.addEventListener('keyup', function () {
+                                input.value = input.value.replace(new RegExp("([^a-zA-Z0-9\-]+)", "g"), "");
+                            });
                         },
                         switchSearchMode: function (type) {
                             let self = this;

--- a/share/templates/dist/search.html.ep
+++ b/share/templates/dist/search.html.ep
@@ -96,7 +96,6 @@
                             let self = this;
                             if (inc < 10) inc++;
                             let pdists = dists.splice(0, inc);
-                            console.log(dists);
                             self.request('/dist', { dists: pdists }, function (res) {
                                 res.dists.forEach(function (dist) {
                                     self.render_dist(dist);

--- a/share/templates/dist/view.html.ep
+++ b/share/templates/dist/view.html.ep
@@ -14,10 +14,8 @@
                 <option value="0" selected>all</option>
                 <option value="50">50</option>
                 <option value="25">25</option>
-                <option value="10>10</option>
+                <option value="10">10</option>
                 <option value="5">5</option>
-                <option value="4">4</option>
-                <option value="2">2</option>
             </select>
         </div>
     </form>

--- a/share/templates/dist/view.html.ep
+++ b/share/templates/dist/view.html.ep
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highcharts/5.0.12/css/highcharts.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script
+src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/5.0.12/highcharts.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.3.4/vue.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.6.0/vue-router.min.js"></script>
+<title>Dashboard</title>
+<div class="container" id="app">
+    <div style="display: flex; justify-content: space-between; align-items: flex-end;">
+        <h1>Dashboard</h1>
+        <p style="vertical-align: middle"><i class="fa fa-2x fa-info-circle text-info" aria-hidden="true"></i> Click a version bar to see reports for that version</p>
+    </div>
+    <form class="form form-inline" @submit.prevent="fetchRelease">
+        <input class="form-control col-md-3" type="text" placeholder="Distribution name" v-model="dist">
+        <select class="form-control col-md-3" name="versions" v-model="size">
+            <option value="0">all</option>
+            <option value="50">50</option>
+            <option value="25">25</option>
+            <option value="10" selected>10</option>
+            <option value="5">5</option>
+        </select>
+        <button class="btn btn-primary">Refresh</button>
+    </form>
+
+    <div style="position: relative; width: 100%; height: 400px;">
+        <div v-show="fetchingRelease" style="opacity: 0.8; background-color: white; position: absolute; z-index: 10; left: 0; top: 0; bottom: 0; right: 0;
+        display: flex; flex: 1 1; align-items: center; justify-content: center">
+            <i style="display: flex-item; color: #ccc; font-size: 1500%" class="fa fa-spinner fa-pulse fa-fw"></i>
+        </div>
+        <div id="release-chart" style="width: 100%; height: 400px"></div>
+    </div>
+
+    <div v-show="version" style="display: flex; justify-content: space-between; align-items: flex-end;">
+        <h2 id="summary">{{version}}</h2>
+        <p style="vertical-align: middle"><i class="fa fa-2x fa-info-circle text-info" aria-hidden="true"></i> Click a pie piece to show reports for that OS/grade</p>
+    </div>
+    <div style="position: relative; height: 300px">
+        <div v-show="fetchingSummary" style="opacity: 0.8; background-color: white; position: absolute; z-index: 10; left: 0; top: 0; bottom: 0; right: 0;
+        display: flex; flex: 1 1; align-items: center; justify-content: center">
+            <i style="display: flex-item; color: #ccc; font-size: 1500%" class="fa fa-spinner fa-pulse fa-fw"></i>
+        </div>
+        <div style="display: flex" v-show="summary.length">
+            <div id="os-linux" style="width: 25%; height: 300px"></div>
+            <div id="os-win" style="width: 25%; height: 300px"></div>
+            <div id="os-osx" style="width: 25%; height: 300px"></div>
+            <div id="os-other" style="width: 25%; height: 300px"></div>
+        </div>
+    </div>
+
+    <table v-show="summary.length" class="table table-striped">
+        <thead>
+            <tr>
+                <th style="width: 1.4em"></th>
+                <th style="width: 6em; text-align: center">Grade</th>
+                <th style="width: 8em; text-align: center">Perl</th>
+                <th style="width: 40%">Platform</th>
+                <th>Tester</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr v-for="s in filteredSummaryRows()">
+                <td style="text-align: center"><a :href="'http://www.cpantesters.org/cpan/report/' + s.guid" title="View full report"><i class="fa fa-file-text-o" aria-hidden="true"></i></a></td>
+                <td style="text-align: center" :class="_gradeClass(s.grade)">{{ s.grade }}</td>
+                <td style="text-align: center">{{ s.perl }}</td>
+                <td>{{ s.platform }} ({{ s.osname }})</td>
+                <td>{{ s.reporter.replace( /\@[^.]+/, '@[...]' ) }}</td>
+            </tr>
+        </tbody>
+    </table>
+
+</div>
+<script>
+
+var vm = new Vue({
+    el: '#app',
+    data: function () {
+        var self = this;
+        var params = (new URL(document.location)).searchParams;
+        var obj = {
+            version: params.get( 'version' ),
+            dist: params.get( 'dist' ),
+            size: 10,
+            summary: [],
+            fetchingRelease: false,
+            fetchingSummary: false,
+            chart: {},
+            summaryFilter: { }
+        };
+        if ( obj.dist ) {
+            setTimeout( function () { self.fetchRelease({ replace: false }); }, 10 );
+        }
+        if ( obj.version ) {
+            setTimeout( function () { self.fetchSummary({ scroll: false }); }, 10 );
+        }
+        return obj;
+    },
+    methods: {
+
+        _gradeClass: function ( grade ) {
+            return {
+                pass: 'bg-success',
+                fail: 'bg-danger',
+                na: 'bg-info',
+                unknown: 'bg-warning'
+            }[ grade ];
+        },
+
+        filteredSummaryRows: function () {
+            var f = this.summaryFilter;
+            if ( !f.osname && !f.grade ) {
+                return this.summary;
+            }
+            if ( f.osname == "other" ) {
+                return this.summary.filter( function ( r ) {
+                    return r.osname != 'darwin' &&
+                    r.osname.toLowerCase() != 'mswin32' &&
+                    r.osname != 'linux' && r.grade == f.grade;
+                } );
+            }
+            return this.summary.filter( function ( r ) {
+                return r.osname.toLowerCase() == f.osname && r.grade == f.grade;
+            } );
+        },
+
+        fetchSummary: function (opt) {
+            var self = this;
+            self.summary = [];
+            self.fetchingSummary = true;
+
+            this.summaryFilter = {};
+            // clear all other filters
+            for ( var name in self.chart ) {
+                var points = self.chart[ name ].getSelectedPoints();
+                for ( var j = 0; j < points.length; j++ ) {
+                    points[j].select( false, false );
+                }
+            }
+
+            history.pushState(
+                { dist: this.dist, version: this.version },
+                "",
+                "?dist=" + this.dist + "&version=" + this.version
+            );
+
+            $.getJSON( '//<%= config->{api_host} %>/v3/summary/' + this.dist + '/' + this.version + '?perl_maturity=stable', function (data ) {
+                self.fetchingSummary = false;
+                self.summary = data;
+
+                var osnames = {
+                    linux: { id: "os-linux", title: 'Linux' },
+                    mswin32: { id: "os-win", title: 'Windows' },
+                    darwin: { id: "os-osx", title: 'MacOSX' },
+                    other: { id: "os-other", title: 'Other' }
+                };
+                var series = {
+                    linux: { count: 0, pass: [], fail: [], na: [], unknown: [] },
+                    mswin32: { count: 0, pass: [], fail: [], na: [], unknown: [] },
+                    darwin: { count: 0, pass: [], fail: [], na: [], unknown: [] },
+                    other: { count: 0, pass: [], fail: [], na: [], unknown: [] }
+                };
+
+                for ( var i = 0; i < data.length; i++ ) {
+                    var s = series[ data[i].osname.toLowerCase() ] || series.other;
+                    s[ data[i].grade ]++;
+                    s.count++;
+                }
+
+                for ( var os in osnames ) {
+                    var count = 0;
+                    self.chart[ os ] = Highcharts.chart( osnames[os]['id'], {
+                        defs: {
+                            osname: os
+                        },
+                        chart: {
+                            type: 'pie',
+                        },
+                        plotOptions: {
+                            pie: {
+                                allowPointSelect: true,
+                                cursor: 'pointer',
+                                dataLabels: {
+                                    enabled: false
+                                },
+                                showInLegend: true,
+                                events: {
+                                    click: function ( event ) {
+                                        if ( event.point.selected ) {
+                                            self.summaryFilter = {};
+                                            return;
+                                        }
+
+                                        // clear all other filters
+                                        for ( var name in self.chart ) {
+                                            var points = self.chart[ name ].getSelectedPoints();
+                                            for ( var j = 0; j < points.length; j++ ) {
+                                                points[j].select( false, false );
+                                            }
+                                        }
+
+                                        // set this filter
+                                        self.summaryFilter = {
+                                            osname: event.point.osname,
+                                            grade: event.point.grade,
+                                        };
+                                    }
+                                }
+                            }
+                        },
+                        title: {
+                            text: osnames[os]['title'] + ' (' + series[os].count + ')'
+                        },
+                        series: [{
+                            name: 'Reports',
+                            colorByPoint: true,
+                            data: [
+                                { name: 'Pass', y: series[os].pass, grade: "pass", osname: os },
+                                { name: 'Fail', y: series[os].fail, grade: "fail", osname: os },
+                                { name: 'NA', y: series[os].na, grade: "na", osname: os },
+                                { name: 'Unknown', y: series[os].unknown, grade: "unknown", osname: os }
+                            ]
+                        }]
+                    });
+                }
+
+                // Scroll into view
+                if ( !opt || opt.scroll !== false ) {
+                    setTimeout(
+                        function () {
+                            window.scrollTo( 0, $( '#summary' ).offset().top );
+                        }, 10
+                    );
+                }
+            } );
+        },
+
+        fetchRelease: function ( opt ) {
+            if ( !this.dist ) { return; }
+            var self = this;
+            self.fetchingRelease = true;
+
+            if ( opt.replace !== false ) {
+                this.version = null;
+                this.summary = [];
+            }
+
+            history.pushState(
+                { dist: this.dist },
+                "",
+                "?dist=" + this.dist
+            );
+
+            var show_versions = this.size;
+
+            $.getJSON('http://<%= config->{api_host} %>/v3/upload/dist/' + this.dist, function (data) {
+                var sorted = data.sort( function (a, b) { return a.released < b.released ? -1 : a.released > b.released ? 1 : 0 } );
+                if ( show_versions ) {
+                    sorted = sorted.slice( -show_versions );
+                }
+                var versions = sorted.map( function (d) { return d.version } );
+
+                var done = 0;
+                var results = [];
+
+                var checkDone = function () {
+                    if ( done < show_versions ) { return; }
+                    self.fetchingRelease = false;
+                    var series = { pass: [], fail: [], na: [], unknown: [] };
+                    for ( var i = 0; i < results.length; i++ ) {
+                        series.pass.push( results[i].pass );
+                        series.fail.push( results[i].fail );
+                        series.na.push( results[i].na );
+                        series.unknown.push( results[i].unknown );
+                    }
+                    var myChart = Highcharts.chart('release-chart', {
+                        chart: {
+                            type: 'column',
+                        },
+                        plotOptions: {
+                            column: {
+                                stacking: 'normal',
+                                events: {
+                                    click: function ( event ) {
+                                        self.version = event.point.category;
+                                        self.fetchSummary();
+                                    }
+                                }
+                            }
+                        },
+                        title: {
+                            text: 'Report Summary'
+                        },
+                        xAxis: {
+                            title: { text: 'Version' },
+                            categories: versions
+                        },
+                        yAxis: {
+                            title: {
+                                text: 'Reports by Grade'
+                            }
+                        },
+                        series: [
+                            { name: 'Pass', data: series.pass },
+                            { name: 'Fail', data: series.fail },
+                            { name: 'NA', data: series.na },
+                            { name: 'Unknown', data: series.unknown }
+                        ]
+                    });
+                };
+
+                versions.forEach( function ( version ) {
+                    $.getJSON('http://<%= config->{api_host} %>/v3/release/dist/' + self.dist + '/' + version )
+                     .done( function (data) {
+                        done++;
+                        results.push( data );
+                        checkDone();
+                     } )
+                     .fail( function ( jqXHR ) {
+                        done++;
+                        checkDone();
+                     } );
+                } );
+            });
+        }
+
+    }
+});
+
+window.onpopstate = function (event) {
+    vm.dist = event.state.dist;
+    if ( vm.dist ) {
+        vm.fetchRelease({ replace: false });
+    }
+    vm.version = event.state.version;
+    if ( vm.version ) {
+        vm.fetchSummary({ scroll: false });
+    }
+};
+
+</script>
+

--- a/share/templates/dist/view.html.ep
+++ b/share/templates/dist/view.html.ep
@@ -1,185 +1,254 @@
-<!DOCTYPE html>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highcharts/5.0.12/css/highcharts.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-<script
-src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/5.0.12/highcharts.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.3.4/vue.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.6.0/vue-router.min.js"></script>
-<title>Dashboard</title>
 <div class="container" id="app">
     <div style="display: flex; justify-content: space-between; align-items: flex-end;">
-        <h1>Dashboard</h1>
+        <h1>Dist - <%= $dist %></h1>
         <p style="vertical-align: middle"><i class="fa fa-2x fa-info-circle text-info" aria-hidden="true"></i> Click a version bar to see reports for that version</p>
     </div>
-    <form class="form form-inline" @submit.prevent="fetchRelease">
-        <input class="form-control col-md-3" type="text" placeholder="Distribution name" v-model="dist">
-        <select class="form-control col-md-3" name="versions" v-model="size">
-            <option value="0">all</option>
-            <option value="50">50</option>
-            <option value="25">25</option>
-            <option value="10" selected>10</option>
-            <option value="5">5</option>
-        </select>
-        <button class="btn btn-primary">Refresh</button>
+    <form id="dist-search" class="form form-inline flex flex-justify">
+        <div class="hide">
+            <input class="form-control col-md-3" type="text" placeholder="Distribution name">
+            <button class="btn btn-primary">Search</button>
+        </div>
+        <div></div>
+        <div>
+            <select class="form-control col-md-3" name="dist_graph_size">
+                <option value="0" selected>all</option>
+                <option value="50">50</option>
+                <option value="25">25</option>
+                <option value="10>10</option>
+                <option value="5">5</option>
+                <option value="4">4</option>
+                <option value="2">2</option>
+            </select>
+        </div>
     </form>
 
-    <div style="position: relative; width: 100%; height: 400px;">
-        <div v-show="fetchingRelease" style="opacity: 0.8; background-color: white; position: absolute; z-index: 10; left: 0; top: 0; bottom: 0; right: 0;
-        display: flex; flex: 1 1; align-items: center; justify-content: center">
-            <i style="display: flex-item; color: #ccc; font-size: 1500%" class="fa fa-spinner fa-pulse fa-fw"></i>
-        </div>
-        <div id="release-chart" style="width: 100%; height: 400px"></div>
-    </div>
+    <div id="release-graph" class="loading-content"></div>
+    <form id="release-search" class="form form-inline flex flex-justify">
+        <div>
+            <h4>Select a release: </h4>
+            <select class="form-control col-md-3" name="releases">
 
-    <div v-show="version" style="display: flex; justify-content: space-between; align-items: flex-end;">
-        <h2 id="summary">{{version}}</h2>
-        <p style="vertical-align: middle"><i class="fa fa-2x fa-info-circle text-info" aria-hidden="true"></i> Click a pie piece to show reports for that OS/grade</p>
-    </div>
-    <div style="position: relative; height: 300px">
-        <div v-show="fetchingSummary" style="opacity: 0.8; background-color: white; position: absolute; z-index: 10; left: 0; top: 0; bottom: 0; right: 0;
-        display: flex; flex: 1 1; align-items: center; justify-content: center">
-            <i style="display: flex-item; color: #ccc; font-size: 1500%" class="fa fa-spinner fa-pulse fa-fw"></i>
+            </select>
         </div>
-        <div style="display: flex" v-show="summary.length">
-            <div id="os-linux" style="width: 25%; height: 300px"></div>
-            <div id="os-win" style="width: 25%; height: 300px"></div>
-            <div id="os-osx" style="width: 25%; height: 300px"></div>
-            <div id="os-other" style="width: 25%; height: 300px"></div>
+        <div>
+            <p style="vertical-align: middle"><i class="fa fa-2x fa-info-circle text-info" aria-hidden="true"></i> Click a pie piece to show reports for that OS/grade</p>
         </div>
+    </form>
+    <div id="version-graphs" class="flex">
+        <div id="linux-graph" class="loading-content small-graph"></div>
+        <div id="darwin-graph" class="loading-content small-graph"></div>
+        <div id="mswin32-graph" class="loading-content small-graph"></div>
+        <div id="other-graph" class="loading-content small-graph"></div>
     </div>
+    <div id="reports" class="loading-content">
+          <table class="table table-striped hide">
+                <thead>
+                    <tr>
+                        <th style="width:20px"></th>
+                        <th class="text-center">Grade</th>
+                        <th class="text-center">Perl</th>
+                        <th class="text-center">OS</th>
+                        <th class="text-center">Platform</th>
+                        <th class="text-center">Tester</th>
+                        <th class="text-center">Time</th>
+                    </tr>
+                </thead>
+                <tbody>
 
-    <table v-show="summary.length" class="table table-striped">
-        <thead>
-            <tr>
-                <th style="width: 1.4em"></th>
-                <th style="width: 6em; text-align: center">Grade</th>
-                <th style="width: 8em; text-align: center">Perl</th>
-                <th style="width: 40%">Platform</th>
-                <th>Tester</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr v-for="s in filteredSummaryRows()">
-                <td style="text-align: center"><a :href="'http://www.cpantesters.org/cpan/report/' + s.guid" title="View full report"><i class="fa fa-file-text-o" aria-hidden="true"></i></a></td>
-                <td style="text-align: center" :class="_gradeClass(s.grade)">{{ s.grade }}</td>
-                <td style="text-align: center">{{ s.perl }}</td>
-                <td>{{ s.platform }} ({{ s.osname }})</td>
-                <td>{{ s.reporter.replace( /\@[^.]+/, '@[...]' ) }}</td>
-            </tr>
-        </tbody>
-    </table>
+                </tbody>
+            </table>
 
+    </div>
 </div>
+<template id="reports-row-template">
+    <tr>
+        <td class="text-center">
+            <a target="_blank" data-id="report" href="/cpan/report/70688390-3e50-11e7-bbe8-c4ce9b75e0ae" title="View full report"><i aria-hidden="true" class="fa fa-file-text-o"></i></a>
+        </td>
+        <td data-id="state" class="text-center"></td>
+        <td data-id="perl" class="text-center"></td>
+        <td data-id="osname" class="text-center"></td>
+        <td data-id="platform" class="text-center"></td>
+        <td data-id="tester" class="text-center"></td>
+        <td data-id="fulldate" class="text-center"></td>
+    </tr>
+</template>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/5.0.12/highcharts.js"></script>
 <script>
-
-var vm = new Vue({
-    el: '#app',
-    data: function () {
-        var self = this;
-        var params = (new URL(document.location)).searchParams;
-        var obj = {
-            version: params.get( 'version' ),
-            dist: params.get( 'dist' ),
-            size: 10,
-            summary: [],
-            fetchingRelease: false,
-            fetchingSummary: false,
-            chart: {},
-            summaryFilter: { }
+    (function () {
+        let DistView = function (dist, version) {
+            this.dist = dist;
+            this.version = version;
+            this.dist_search = document.querySelector('#dist-search');
+            this.size = this.dist_search.querySelector('[name="dist_graph_size"]').value;
+            this.release_search = document.querySelector('#release-search select');
+            this.reports = document.querySelector('#reports');
+            this.reports_row_template = document.querySelector('#reports-row-template');
+            this.release_data = [];
+            this.report_data = { };
+            this.report_graphs = { };
+            this.report_filter = { };
+            return this.init();
         };
-        if ( obj.dist ) {
-            setTimeout( function () { self.fetchRelease({ replace: false }); }, 10 );
-        }
-        if ( obj.version ) {
-            setTimeout( function () { self.fetchSummary({ scroll: false }); }, 10 );
-        }
-        return obj;
-    },
-    methods: {
 
-        _gradeClass: function ( grade ) {
-            return {
-                pass: 'bg-success',
-                fail: 'bg-danger',
-                na: 'bg-info',
-                unknown: 'bg-warning'
-            }[ grade ];
-        },
-
-        filteredSummaryRows: function () {
-            var f = this.summaryFilter;
-            if ( !f.osname && !f.grade ) {
-                return this.summary;
-            }
-            if ( f.osname == "other" ) {
-                return this.summary.filter( function ( r ) {
-                    return r.osname != 'darwin' &&
-                    r.osname.toLowerCase() != 'mswin32' &&
-                    r.osname != 'linux' && r.grade == f.grade;
-                } );
-            }
-            return this.summary.filter( function ( r ) {
-                return r.osname.toLowerCase() == f.osname && r.grade == f.grade;
-            } );
-        },
-
-        fetchSummary: function (opt) {
-            var self = this;
-            self.summary = [];
-            self.fetchingSummary = true;
-
-            this.summaryFilter = {};
-            // clear all other filters
-            for ( var name in self.chart ) {
-                var points = self.chart[ name ].getSelectedPoints();
-                for ( var j = 0; j < points.length; j++ ) {
-                    points[j].select( false, false );
+        DistView.prototype = {
+            init: function () {
+                this.dist_search.querySelector('input').value = this.dist;
+                this.initEvents();
+                this.fetchReleases();
+            },
+            initEvents: function () {
+                let self = this;
+                self.dist_search.querySelector('[name="dist_graph_size"]').addEventListener('change', function (evt) {
+                    self.size = evt.target.value;
+                    self.drawReleaseGraph(self.release_data);
+                });
+                self.release_search.addEventListener('change', function (evt) {
+                    self.version = evt.target.value;
+                    self.fetchReports(self.version);
+                });
+            },
+            setVersion: function (version) {
+                let self = this;
+                self.version = version;
+                self.release_search.value = version;
+                self.release_search.dispatchEvent(new Event('change'))
+            },
+            fetchReleases: function () {
+                let self = this;
+                self.request('/dist/' + self.dist + '/releases', {}, function (res) {
+                    if (!res.dists.length) return;
+                    self.release_data = res.dists.reverse();
+                    self.drawReleaseGraph(self.release_data);
+                    self.drawReleaseSelector(self.release_data);
+                    if (self.version == 'latest') {
+                        self.version =  self.release_data[0].version;
+                    }
+                    self.fetchReports(self.version);
+                });
+            },
+            clearReports: function () {
+                let self = this;
+                self.report_filter = {};
+                for ( let key in self.report_graphs ) {
+                    let g = document.querySelector('#' + key + '-graph');
+                    g.innerHTML = '';
+                    g.classList.add('loading-content');
                 }
-            }
+                self.report_graphs = {};
+                self.reports.classList.add('loading-content');
+                self.reports.querySelector('table').classList.add('hide');
+            },
+            fetchReports: function (version) {
+                let self = this;
 
-            history.pushState(
-                { dist: this.dist, version: this.version },
-                "",
-                "?dist=" + this.dist + "&version=" + this.version
-            );
+                self.clearReports();
 
-            $.getJSON( '//<%= config->{api_host} %>/v3/summary/' + this.dist + '/' + this.version + '?perl_maturity=stable', function (data ) {
-                self.fetchingSummary = false;
-                self.summary = data;
+                if (self.report_data[version]) {
+                    self.drawReportGraphs(self.report_data[version]);
+                    self.drawReportTable(self.report_data[version]);
+                    return;
+                }
 
-                var osnames = {
-                    linux: { id: "os-linux", title: 'Linux' },
-                    mswin32: { id: "os-win", title: 'Windows' },
-                    darwin: { id: "os-osx", title: 'MacOSX' },
-                    other: { id: "os-other", title: 'Other' }
+                self.request('/dist/' + self.dist + '/releases/' + version, {}, function (res) {
+                    if (!res.reports || !res.reports.length) return;
+                    self.report_data[version] = res.reports;
+                    if (version != self.version) return;
+                    self.drawReportGraphs(self.report_data[version]);
+                    self.drawReportTable(self.report_data[version]);
+                });
+            },
+            drawReleaseSelector: function (data) {
+                let self = this;
+                self.release_search.innerHTML = '';
+                data.forEach(function (d) {
+                    let o = new Option(d.version, d.version);
+                    if (d.version == self.version) {
+                        o.selected = true;
+                    }
+                    self.release_search.appendChild(o);
+                });
+            },
+            drawReleaseGraph: function (data) {
+                let self = this;
+                let size = this.size != 0 && this.size < data.length ? this.size : data.length;
+                let series = { version: [], pass: [], fail: [], na: [], unknown: [] };
+                for ( var i = 0; i < size; i++ ) {
+                    ['version', 'pass', 'fail', 'na', 'unknown'].forEach(function (n) {
+                        series[n].push(data[i][n]);
+                    });
+                }
+
+                ['version', 'pass', 'fail', 'na', 'unknown'].forEach(function (n) {
+                    series[n] =  series[n].reverse();
+                });
+
+                let myChart = Highcharts.chart('release-graph', {
+                    chart: {
+                        type: 'column',
+                    },
+                    plotOptions: {
+                        column: {
+                            stacking: 'normal',
+                            events: {
+                                click: function (event) {
+                                    self.setVersion(event.point.category);
+                                }
+                            }
+                        }
+                    },
+                    title: {
+                        text: 'Report Summary'
+                    },
+                    xAxis: {
+                        title: { text: 'Version' },
+                        categories: series.version
+                    },
+                    yAxis: {
+                        title: {
+                            text: 'Reports by Grade'
+                        }
+                    },
+                    series: [
+                        { name: "Pass", data: series.pass, color: '#dff0d8' },
+                        { name: "Fail", data: series.fail, color: '#f2dede' },
+                        { name: "NA", data: series.na, color: '#fcf8e3' },
+                        { name: "Unknown", data: series.unknown, color: '#f6ddc3' }
+                    ]
+                });
+
+                document.querySelector('#release-graph').classList.remove('loading-content');
+            },
+            drawReportGraphs: function (data) {
+                let self = this;
+                let series = {
+                    linux: { title: "Linux", count: 0, pass: 0, fail: 0, na: 0, unknown: 0 },
+                    mswin32: { title: "Windows", count: 0, pass: 0, fail: 0, na: 0, unknown: 0 },
+                    darwin: { title: "MacOSX", count: 0, pass: 0, fail: 0, na: 0, unknown: 0 },
+                    other: { title: "Other", count: 0, pass: 0, fail: 0, na: 0, unknown: 0 },
                 };
-                var series = {
-                    linux: { count: 0, pass: [], fail: [], na: [], unknown: [] },
-                    mswin32: { count: 0, pass: [], fail: [], na: [], unknown: [] },
-                    darwin: { count: 0, pass: [], fail: [], na: [], unknown: [] },
-                    other: { count: 0, pass: [], fail: [], na: [], unknown: [] }
-                };
 
-                for ( var i = 0; i < data.length; i++ ) {
-                    var s = series[ data[i].osname.toLowerCase() ] || series.other;
-                    s[ data[i].grade ]++;
+                data.forEach(function (d) {
+                    let s = series[ d.osname.toLowerCase() ] || series.other;
+                    s[ d.state ]++;
                     s.count++;
-                }
+                });
 
-                for ( var os in osnames ) {
-                    var count = 0;
-                    self.chart[ os ] = Highcharts.chart( osnames[os]['id'], {
+                ['linux', 'mswin32', 'darwin', 'other'].forEach(function (os) {
+
+                    self.report_graphs[os] = Highcharts.chart( os + "-graph", {
                         defs: {
                             osname: os
                         },
                         chart: {
                             type: 'pie',
                         },
+                        colors: ["#dff0d8", "#f2dede", "#fcf8e3", "#f6ddc3" ],
                         plotOptions: {
                             pie: {
+                                colorByPoint: true,
                                 allowPointSelect: true,
                                 cursor: 'pointer',
                                 dataLabels: {
@@ -189,156 +258,130 @@ var vm = new Vue({
                                 events: {
                                     click: function ( event ) {
                                         if ( event.point.selected ) {
-                                            self.summaryFilter = {};
+                                            self.report_filter = {};
+                                            self.drawReportTable();
                                             return;
                                         }
 
                                         // clear all other filters
-                                        for ( var name in self.chart ) {
-                                            var points = self.chart[ name ].getSelectedPoints();
+                                        for ( var name in self.report_graphs ) {
+                                            var points = self.report_graphs[ name ].getSelectedPoints();
                                             for ( var j = 0; j < points.length; j++ ) {
                                                 points[j].select( false, false );
                                             }
                                         }
 
                                         // set this filter
-                                        self.summaryFilter = {
+                                        self.report_filter = {
                                             osname: event.point.osname,
-                                            grade: event.point.grade,
+                                            state: event.point.grade,
                                         };
+
+
+                                        self.drawReportTable();
                                     }
                                 }
                             }
                         },
                         title: {
-                            text: osnames[os]['title'] + ' (' + series[os].count + ')'
+                            text: series[os]['title'] + ' (' + series[os].count + ')'
                         },
                         series: [{
                             name: 'Reports',
-                            colorByPoint: true,
                             data: [
-                                { name: 'Pass', y: series[os].pass, grade: "pass", osname: os },
+                                { name: 'Pass',  y: series[os].pass, grade: "pass", osname: os },
                                 { name: 'Fail', y: series[os].fail, grade: "fail", osname: os },
-                                { name: 'NA', y: series[os].na, grade: "na", osname: os },
+                                { name: 'NA',  y: series[os].na, grade: "na", osname: os },
                                 { name: 'Unknown', y: series[os].unknown, grade: "unknown", osname: os }
                             ]
                         }]
-                    });
-                }
 
-                // Scroll into view
-                if ( !opt || opt.scroll !== false ) {
-                    setTimeout(
-                        function () {
-                            window.scrollTo( 0, $( '#summary' ).offset().top );
-                        }, 10
+                    });
+
+                    document.querySelector('#' + os + '-graph').classList.remove('loading-content');
+                });
+            },
+            drawReportTable: function (data) {
+                let self = this;
+                if (!data) data = self.report_data[self.version];
+                data = self.filterReportTable(data);
+                self.reports.classList.remove('loading-content');
+                self.reports.querySelector('table').classList.remove('hide');
+                let tbody = self.reports.querySelector('tbody');
+                tbody.innerHTML = '';
+                data.forEach(function (d) {
+                    let tr = self.reports_row_template.content.cloneNode(true);
+                    let state = tr.querySelector('[data-id="state"]');
+                    state.innerText = d.state;
+                    state.classList.add(
+                        d.state == 'pass'
+                            ? 'bg-success'
+                            : d.state == 'fail'
+                                ? 'bg-danger'
+                                : d.state == 'na'
+                                ? 'bg-warning'
+                                : 'bg-unknown'
                     );
-                }
-            } );
-        },
 
-        fetchRelease: function ( opt ) {
-            if ( !this.dist ) { return; }
-            var self = this;
-            self.fetchingRelease = true;
+                    tr.querySelector('[data-id="report"]').href = 'https://www.cpantesters.org/cpan/report/' + d.guid;
+                    d.fulldate = self.fixWeirdDate(d.fulldate);
 
-            if ( opt.replace !== false ) {
-                this.version = null;
-                this.summary = [];
-            }
-
-            history.pushState(
-                { dist: this.dist },
-                "",
-                "?dist=" + this.dist
-            );
-
-            var show_versions = this.size;
-
-            $.getJSON('http://<%= config->{api_host} %>/v3/upload/dist/' + this.dist, function (data) {
-                var sorted = data.sort( function (a, b) { return a.released < b.released ? -1 : a.released > b.released ? 1 : 0 } );
-                if ( show_versions ) {
-                    sorted = sorted.slice( -show_versions );
-                }
-                var versions = sorted.map( function (d) { return d.version } );
-
-                var done = 0;
-                var results = [];
-
-                var checkDone = function () {
-                    if ( done < show_versions ) { return; }
-                    self.fetchingRelease = false;
-                    var series = { pass: [], fail: [], na: [], unknown: [] };
-                    for ( var i = 0; i < results.length; i++ ) {
-                        series.pass.push( results[i].pass );
-                        series.fail.push( results[i].fail );
-                        series.na.push( results[i].na );
-                        series.unknown.push( results[i].unknown );
-                    }
-                    var myChart = Highcharts.chart('release-chart', {
-                        chart: {
-                            type: 'column',
-                        },
-                        plotOptions: {
-                            column: {
-                                stacking: 'normal',
-                                events: {
-                                    click: function ( event ) {
-                                        self.version = event.point.category;
-                                        self.fetchSummary();
-                                    }
-                                }
-                            }
-                        },
-                        title: {
-                            text: 'Report Summary'
-                        },
-                        xAxis: {
-                            title: { text: 'Version' },
-                            categories: versions
-                        },
-                        yAxis: {
-                            title: {
-                                text: 'Reports by Grade'
-                            }
-                        },
-                        series: [
-                            { name: 'Pass', data: series.pass },
-                            { name: 'Fail', data: series.fail },
-                            { name: 'NA', data: series.na },
-                            { name: 'Unknown', data: series.unknown }
-                        ]
+                    ['state', 'perl', 'osname', 'platform', 'tester', 'fulldate'].forEach(function (k) {
+                        tr.querySelector('[data-id="' + k + '"]').innerText = d[k];
                     });
-                };
 
-                versions.forEach( function ( version ) {
-                    $.getJSON('http://<%= config->{api_host} %>/v3/release/dist/' + self.dist + '/' + version )
-                     .done( function (data) {
-                        done++;
-                        results.push( data );
-                        checkDone();
-                     } )
-                     .fail( function ( jqXHR ) {
-                        done++;
-                        checkDone();
-                     } );
-                } );
-            });
-        }
+                    tbody.appendChild(tr);
+                });
+            },
+            filterReportTable: function (data) {
+                let filter = this.report_filter;
+                if ( !filter.osname ) {
+                    return data;
+                }
+                return data.filter(function (d) {
 
-    }
-});
+                    if (filter.osname == 'other') {
+                         return ( !d.osname.toLowerCase().match(/^(linux|darwin|mswin32)$/) && filter.state == d.state ) ? 1 : 0;
 
-window.onpopstate = function (event) {
-    vm.dist = event.state.dist;
-    if ( vm.dist ) {
-        vm.fetchRelease({ replace: false });
-    }
-    vm.version = event.state.version;
-    if ( vm.version ) {
-        vm.fetchSummary({ scroll: false });
-    }
-};
+                    }
 
+                    return  (
+                        filter.osname == d.osname.toLowerCase() && filter.state == d.state
+                    ) ? 1 : 0
+                });
+            },
+            fixWeirdDate: function (data) {
+                let regex = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})/g;
+                return data.replace(regex, function (match, y, m, d, h, M) {
+                    return y + '-' + m + '-' + d + ' ' + h + ':' + M;
+                });
+            },
+            queryParams: function (url, params) {
+                let str = "";
+                for (param in params) {
+                    if (str) str += "&";
+                    str += encodeURI(param + "=" + params[param]);
+                }
+                return str ? ( url + "?" + str ) : url;
+            },
+            request: function (url, params, cb) {
+                url = this.queryParams(url, params);
+                fetch(url, {
+                    method: "GET",
+                }).then(function (res) {
+                    return res.json();
+                }).then(function (res) {
+                    cb(res);
+                }).catch(function (res) {
+                     console.log(res);
+                });
+            },
+        };
+
+        let dist = "<%= $dist %>";
+        let version = "<%= $version %>"
+        window.addEventListener('DOMContentLoaded', function () {
+            new DistView(dist, version);
+        });
+    })();
 </script>
-

--- a/share/templates/dist/view.html.ep
+++ b/share/templates/dist/view.html.ep
@@ -23,17 +23,32 @@
     </form>
 
     <div id="release-graph" class="loading-content"></div>
-    <form id="release-search" class="form form-inline flex flex-justify">
+    <form id="release-search" class="form form-inline flex">
         <div>
-            <h4>Select a release: </h4>
+            <h4>Select a version: </h4>
             <select class="form-control col-md-3" name="releases">
 
             </select>
         </div>
+    </form>
+    <div id="version-summary" class="loading-content loading-content-short-height">
+        <div class="hide">
+            <h2 class="text-center"><%= $dist %> Version <span data-id="version">2.2207</span></h2>
+        </div>
+        <div class="flex flex-justify hide">
+            <h4>Total: <span data-id="total"></span></h4>
+            <h4>Pass: <span data-id="pass"></span></h4>
+            <h4>Fail: <span data-id="fail"></span></h4>
+            <h4>NA: <span data-id="na"></span></h4>
+            <h4>Unknown: <span data-id="unknown"></span></h4>
+        </div>
+    </div>
+    <div style="margin-top:1em;" class="flex flex-justify">
+        <div></div>
         <div>
             <p style="vertical-align: middle"><i class="fa fa-2x fa-info-circle text-info" aria-hidden="true"></i> Click a pie piece to show reports for that OS/grade</p>
         </div>
-    </form>
+    </div>
     <div id="version-graphs" class="flex">
         <div id="linux-graph" class="loading-content small-graph"></div>
         <div id="darwin-graph" class="loading-content small-graph"></div>
@@ -86,6 +101,7 @@
             this.release_search = document.querySelector('#release-search select');
             this.reports = document.querySelector('#reports');
             this.reports_row_template = document.querySelector('#reports-row-template');
+            this.version_summary = document.querySelector('#version-summary');
             this.release_data = [];
             this.report_data = { };
             this.report_graphs = { };
@@ -107,6 +123,7 @@
                 });
                 self.release_search.addEventListener('change', function (evt) {
                     self.version = evt.target.value;
+                    self.setReportSummary(self.version);
                     self.fetchReports(self.version);
                 });
             },
@@ -115,6 +132,20 @@
                 self.version = version;
                 self.release_search.value = version;
                 self.release_search.dispatchEvent(new Event('change'))
+            },
+            setReportSummary: function (version) {
+                let self = this;
+                let release = self.release_data.find( d => d.version == version );
+
+                self.version_summary.querySelector('[data-id="version"]').innerText = version;
+
+                release.total = release.pass + release.fail + release.na + release.unknown;
+                ['total', 'pass', 'fail', 'na', 'unknown'].forEach(function (s) {
+                    self.version_summary.querySelector('[data-id="' + s + '"]').innerText = release[s];
+                });
+
+                self.version_summary.querySelectorAll('.hide').forEach( c => c.classList.remove('hide') );
+                self.version_summary.classList.remove('loading-content');
             },
             fetchReleases: function () {
                 let self = this;
@@ -126,6 +157,7 @@
                     if (self.version == 'latest') {
                         self.version =  self.release_data[0].version;
                     }
+                    self.setReportSummary(self.version);
                     self.fetchReports(self.version);
                 });
             },

--- a/share/templates/dist/view.html.ep
+++ b/share/templates/dist/view.html.ep
@@ -283,6 +283,11 @@
                                 }
                             }
                         },
+                        legend: {
+                            labelFormatter: function (l) {
+                                return this.name + ' (' + this.y + ')';
+                            }
+                        },
                         title: {
                             text: series[os]['title'] + ' (' + series[os].count + ')'
                         },


### PR DESCRIPTION
This branch is a fork of https://github.com/cpan-testers/cpantesters-web/pull/33. You will either need to merge that first or merge this and then close that.

This branch updates the https://cpantesters.org/dist/<dist>/<version> pages to have the following interface:
<img width="678" alt="Screenshot 2025-05-24 at 20 04 11" src="https://github.com/user-attachments/assets/c1e3ae03-416a-49c9-a986-37b70108a949" />

I took the code at http://beta.cpantesters.org/chart.html and re-wrote it to be vanilla javascript.

I have several more features I would like to implement but i thought this was a good place to stop with a version 1.